### PR TITLE
add "/usr/bin/kvm" to search options

### DIFF
--- a/lib/vagrant-kvm/util/vm_definition.rb
+++ b/lib/vagrant-kvm/util/vm_definition.rb
@@ -97,7 +97,7 @@ module VagrantPlugins
         def as_libvirt
           # RedHat and Debian-based systems have different executable names
           # depending on version/architectures
-          qemu_bin = [ '/usr/bin/qemu-kvm' ]
+          qemu_bin = [ '/usr/bin/qemu-kvm', '/usr/bin/kvm' ]
           qemu_bin << '/usr/bin/qemu-system-x86_64' if @arch.match(/64$/)
           qemu_bin << '/usr/bin/qemu-system-i386'   if @arch.match(/^i.86$/)
 


### PR DESCRIPTION
As a followup to your comment in #1: yes `/usr/bin/kvm` is present, for now at least (remember that qemu 1.2+ is still in "experimental", so this could very well change).
