### PR TITLE
Allow to use the same base box in multiple VMs

### DIFF
--- a/lib/vagrant-kvm/util/vm_definition.rb
+++ b/lib/vagrant-kvm/util/vm_definition.rb
@@ -51,7 +51,7 @@ module VagrantPlugins
           doc = Nokogiri::XML(definition)
           # we don't need no namespace
           doc.remove_namespaces!
-          @name = Time.now.to_i.to_s + '_' + doc.at_css("VirtualSystemIdentifier").content
+          @name = Dir.pwd.split('/').last + '_' + doc.at_css("VirtualSystemIdentifier").content
           devices = doc.css("VirtualHardwareSection Item")
           for device in devices
             case device.at_css("ResourceType").content


### PR DESCRIPTION
I have two directories which has the same `Vagrantfile`. After I `vagrant up` in one folder, I cannot create VM in second one as domain with same name already exists:

``` shell
/home/jenkins/.vagrant.d/gems/gems/vagrant-kvm-0.1.1/lib/vagrant-kvm/driver/driver.rb:139:in `define_domain_xml': Call to virDomainDefineXML failed: operation failed: domain 'precise32' already exists with uuid f45d5df7-27d0-c8a6-f13d-4ccf84c16de6 (Libvirt::DefinitionError)
```

I've managed to fix this with this small modification, while I find it rather dirty. Please let me know if I can improve it anyhow.
