### PR TITLE
Powered off state is :shutoff not :poweroff

### DIFF
--- a/lib/vagrant-kvm/action.rb
+++ b/lib/vagrant-kvm/action.rb
@@ -63,7 +63,7 @@ module VagrantPlugins
                 b3.use Resume
               end
 
-              b2.use Call, GracefulHalt, :poweroff, :running do |env2, b3|
+              b2.use Call, GracefulHalt, :shutoff, :running do |env2, b3|
                 if !env2[:result]
                   b3.use ForcedHalt
                 end


### PR DESCRIPTION
Now graceful halt hangs because it waits state to become `:poweroff`, while libvirt provides with `:shutoff` state

``` shell
$ virsh list --all
 Id    Name                           State
----------------------------------------------------
 -     precise32                      shut off
```
