### PR TITLE
update readme to show that libvirt-dev package is required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ provider to Vagrant, allowing Vagrant to control and provision KVM/QEMU VM.
 **NOTE:** This plugin requires QEMU 1.2+, it has only been tested on Fedora 18
 and Debian Wheezy at the moment.
 
+**NOTE:** This plugin requires `libvirt-dev` package to be installed (Ubuntu 13.04) or `libvirt-devel` (openSUSE)
+
 ## Features/Limitations
 
 * Provides the same workflow as the Vagrant VirtualBox provider.


### PR DESCRIPTION
To install this plugin there is a dependency that needs to be installed first. 
