### PR TITLE
improve invalid version reporting

### DIFF
--- a/lib/vagrant-kvm/driver/driver.rb
+++ b/lib/vagrant-kvm/driver/driver.rb
@@ -46,9 +46,11 @@ module VagrantPlugins
               raise e
             end
           end
+
           @version = read_version
-          if (@version[:maj] == 1 && @version[:min] < 2) || @version[:maj] < 1
-            raise Vagrant::Errors::KvmInvalidVersion
+          if @version < "1.2.0"
+            raise Errors::KvmInvalidVersion,
+              :actual => @version, :required => "< 1.2.0"
           end
 
           # Get storage pool if it exists
@@ -207,13 +209,13 @@ module VagrantPlugins
 
         # Return the qemu version
         #
-        # @return [Hash] with :maj and :min version numbers
+        # @return [String] of the form "1.2.2"
         def read_version
           # libvirt returns a number like 1002002 for version 1.2.2
-          # we return just the major.minor part like this 1002
           maj = @conn.version / 1000000
           min = (@conn.version - maj*1000000) / 1000
-          { :maj => maj, :min => min }
+          rel = @conn.version % 1000
+          "#{maj}.#{min}.#{rel}"
         end
 
         # Resumes the previously paused virtual machine.

--- a/lib/vagrant-kvm/errors.rb
+++ b/lib/vagrant-kvm/errors.rb
@@ -6,6 +6,9 @@ module VagrantPlugins
       class VagrantKVMError < Vagrant::Errors::VagrantError
         error_namespace("vagrant_kvm.errors")
       end
+      class KvmInvalidVersion < VagrantKVMError
+        error_key(:kvm_invalid_version)
+      end
     end
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,3 +2,7 @@ en:
   vagrant_kvm:
     test_message: |-
       This is a test message.
+    errors:
+      kvm_invalid_version: |-
+        Invalid Kvm version detected: %{actual}, but a version %{required} is
+        required.


### PR DESCRIPTION
Hello, I found a NameError when using an unsupported libvirt version that was a bit misleading. This is a fix.

vagrant-kvm-0.1.2/lib/vagrant-kvm/driver/driver.rb:51:in `initialize': uninitialized constant Vagrant::Errors::KvmInvalidVersion (NameError)
