### PR TITLE
ShareFolders after Boot to avoid ssh timeout. Fixes #18

### DIFF
--- a/lib/vagrant-kvm/action.rb
+++ b/lib/vagrant-kvm/action.rb
@@ -18,10 +18,10 @@ module VagrantPlugins
           b.use PruneNFSExports
           b.use NFS
           b.use PrepareNFSSettings
-          b.use ShareFolders
           b.use SetHostname
           #b.use Customize
           b.use Boot
+          b.use ShareFolders
         end
       end
 


### PR DESCRIPTION
To mount the NFS shared folders vagrant tries to ssh to the machine which cannot happen until the machine boots. The timeout is not NFS trying to mount, but ssh trying to setup NFS, so moving ShareFolders after the Boot process fixes this.
