### PR TITLE
switch from raw to qcow2 and lower version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ provider to Vagrant, allowing Vagrant to control and provision KVM/QEMU VM.
 
 **NOTE:** This plugin requires Vagrant 1.1+
 
-**NOTE:** This plugin requires QEMU 1.2+, it has only been tested on Fedora 18
-and Debian Wheezy at the moment.
+**NOTE:** This plugin requires QEMU 1.1+, it has only been tested on:
+* Fedora 18
+* Debian Wheezy
+* Linux Mint Debian Edition
 
 **NOTE:** This plugin requires `libvirt-dev` package to be installed (Ubuntu 13.04) or `libvirt-devel` (openSUSE)
 

--- a/lib/vagrant-kvm/driver/driver.rb
+++ b/lib/vagrant-kvm/driver/driver.rb
@@ -51,9 +51,9 @@ module VagrantPlugins
           end
 
           @version = read_version
-          if @version < "1.2.0"
+          if @version < "1.1.0"
             raise Errors::KvmInvalidVersion,
-              :actual => @version, :required => "< 1.2.0"
+              :actual => @version, :required => "< 1.1.0"
           end
 
           # Get storage pool if it exists

--- a/templates/libvirt_domain.erb
+++ b/templates/libvirt_domain.erb
@@ -7,7 +7,7 @@
 <currentMemory unit='KiB'><%= memory%></currentMemory>
 <vcpu placement='static'><%= cpus %></vcpu>
   <os>
-  <type arch='<%= arch %>' machine='pc-1.2'>hvm</type>
+  <type arch='<%= arch %>' machine='pc-1.1'>hvm</type>
     <boot dev='hd'/>
   </os>
   <features>


### PR DESCRIPTION
Raw images are quite big since they get fully allocated all the time. I believe that qcow2 is a better choice for multiple reasons. Please http://en.wikibooks.org/wiki/QEMU/Images#Image_types for more details.
