### PR TITLE
kvm: add vnc console

### DIFF
--- a/templates/libvirt_domain.erb
+++ b/templates/libvirt_domain.erb
@@ -48,6 +48,7 @@
     <sound model='ich6'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
     </sound>
+    <graphics type='vnc' port='-1' autoport='yes'/>
     <video>
       <model type='cirrus' vram='9216' heads='1'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>


### PR DESCRIPTION
To debug box image, it is necessary to access image from console when ssh connection failed.

Signed-off-by: Hiroshi Miura miurahr@linux.com
