### PR TITLE
fix degrade in translation

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,8 +5,8 @@ en:
     errors:
       kvm_no_connection: |-
         Cannot connect to KVM through Libvirt. Please check kernel module
-	'kvm' and 'kvm-intel' or 'kvm-amd' are installed and your id is in 
-	group libvirt(in debian/ubuntu).
+        'kvm' and 'kvm-intel' or 'kvm-amd' are installed and your id is in 
+        group libvirt(in debian/ubuntu).
       kvm_invalid_version: |-
         Invalid Kvm version detected: %{actual}, but a version %{required} is
         required.


### PR DESCRIPTION
fix degraded translate file error introduced in #43.

/opt/vagrant/embedded/gems/gems/i18n-0.6.4/lib/i18n/backend/base.rb:180:in `rescue in load_yml': can not load translations from /home/miurahr/.vagrant.d/gems/gems/vagrant-kvm-0.1.3/locales/en.yml: #<Psych::SyntaxError: (/home/miurahr/.vagrant.d/gems/gems/vagrant-kvm-0.1.3/locales/en.yml): found a tab character where an intendation space is expected while scanning a block scalar at line 6 column 26> (I18n::InvalidLocaleData)
