### PR TITLE
Support image types

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,4 +119,5 @@ You need a base MAC address and a private network like in the example.
 There are some provider specific parameter to control VM definition.
 
 * `gui` - boolean for starting VM with VNC enabled.
+* `image_type` - an image format for vm disk: 'raw' or 'qcow2'
 

--- a/lib/vagrant-kvm/action/import.rb
+++ b/lib/vagrant-kvm/action/import.rb
@@ -10,6 +10,10 @@ module VagrantPlugins
           env[:ui].info I18n.t("vagrant.actions.vm.import.importing",
                                :name => env[:machine].box.name)
 
+          # Ignore unsupported image types
+          image_type = env[:machine].provider_config.image_type
+          image_type = 'raw' unless image_type == 'qcow2'
+
           # Import the virtual machine (ovf or libvirt)
           # if a libvirt XML definition is present we use it
           # otherwise we convert the OVF
@@ -17,11 +21,11 @@ module VagrantPlugins
           box_file = env[:machine].box.directory.join("box.xml").to_s
           if File.file?(box_file)
             env[:machine].id = env[:machine].provider.driver.import(
-                        box_file, storage_path)
+                        box_file, storage_path, image_type)
           else
             box_file = env[:machine].box.directory.join("box.ovf").to_s
             env[:machine].id = env[:machine].provider.driver.import_ovf(
-                        box_file, storage_path)
+                        box_file, storage_path, image_type)
           end
 
           # If we got interrupted, then the import could have been

--- a/lib/vagrant-kvm/config.rb
+++ b/lib/vagrant-kvm/config.rb
@@ -21,9 +21,15 @@ module VagrantPlugins
       # @return [Hash]
       attr_reader :network_adapters
 
+      # The VM image format
+      #
+      # @return [String]
+      attr_accessor :image_type
+
       def initialize
         @name             = UNSET_VALUE
         @gui              = UNSET_VALUE
+        @image_type       = UNSET_VALUE
       end
 
       # This is the hook that is called to finalize the object before it
@@ -33,6 +39,8 @@ module VagrantPlugins
         @name = nil if @name == UNSET_VALUE
         # Default is to not show a GUI
         @gui = false if @gui == UNSET_VALUE
+        # Default image type is a sparsed raw
+        @image_type = 'raw' if @image_type == UNSET_VALUE
       end
     end
   end

--- a/lib/vagrant-kvm/driver/driver.rb
+++ b/lib/vagrant-kvm/driver/driver.rb
@@ -94,8 +94,9 @@ module VagrantPlugins
         #
         # @param [String] xml Path to the libvirt XML file.
         # @param [String] path Destination path for the volume.
+        # @param [String] image_type An image type for the volume.
         # @return [String] UUID of the imported VM.
-        def import(xml, path)
+        def import(xml, path, image_type)
           @logger.info("Importing VM")
           # create vm definition from xml
           definition = File.open(xml) { |f|
@@ -108,11 +109,12 @@ module VagrantPlugins
           old_path = File.join(File.dirname(xml), box_disk)
           new_path = File.join(path, new_disk)
           # we use qemu-img convert to preserve image size
-          system("qemu-img convert -p #{old_path} -O raw #{new_path}")
+          system("qemu-img convert -p #{old_path} -O #{image_type} #{new_path}")
           @pool.refresh
           volume = @pool.lookup_volume_by_name(new_disk)
           definition.disk = volume.path
           definition.name = @name
+          definition.image_type = image_type
           # create vm
           @logger.info("Creating new VM")
           domain = @conn.define_domain_xml(definition.as_libvirt)
@@ -124,8 +126,9 @@ module VagrantPlugins
         #
         # @param [String] ovf Path to the OVF file.
         # @param [String] path Destination path for the volume.
+        # @param [String] image_type An image type for the volume.
         # @return [String] UUID of the imported VM.
-        def import_ovf(ovf, path)
+        def import_ovf(ovf, path, image_type)
           @logger.info("Importing OVF definition for VM")
           # create vm definition from ovf
           definition = File.open(ovf) { |f|
@@ -137,11 +140,12 @@ module VagrantPlugins
           @logger.info("Converting volume #{box_disk} to #{new_disk}")
           old_path = File.join(File.dirname(ovf), box_disk)
           new_path = File.join(path, new_disk)
-          system("qemu-img convert -p #{old_path} -O raw #{new_path}")
+          system("qemu-img convert -p #{old_path} -O #{image_type} #{new_path}")
           @pool.refresh
           volume = @pool.lookup_volume_by_name(new_disk)
           definition.disk = volume.path
           definition.name = @name
+          definition.image_type = image_type
           # create vm
           @logger.info("Creating new VM")
           domain = @conn.define_domain_xml(definition.as_libvirt)

--- a/lib/vagrant-kvm/util/vm_definition.rb
+++ b/lib/vagrant-kvm/util/vm_definition.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
         attr_reader :mac
         attr_reader :arch
         attr_reader :network
+        attr_accessor :image_type
 
         def self.list_interfaces(definition)
           nics = {}
@@ -69,7 +70,7 @@ module VagrantPlugins
           # disk volume
           diskref = doc.at_css("DiskSection Disk")["fileRef"]
           @disk = doc.at_css("References File[id='#{diskref}']")["href"]
-
+          @image_type = 'raw'
           # mac address
           # XXX we use only the first nic
           @mac = format_mac(doc.at_css("Machine Hardware Adapter[enabled='true']")['MACAddress'])
@@ -93,6 +94,7 @@ module VagrantPlugins
           @disk = doc.at_css("devices disk source")["file"]
           @mac = doc.at_css("devices interface mac")["address"]
           @network = doc.at_css("devices interface source")["network"]
+          @image_type = doc.at_css("devices disk driver")["type"]
         end
 
         def as_libvirt
@@ -112,6 +114,7 @@ module VagrantPlugins
             :mac => format_mac(@mac),
             :network => @network,
             :gui => @gui,
+            :image_type => @image_type,
             :qemu_bin => qemu_bin.detect { |binary| File.exists? binary }
           })
           xml

--- a/templates/libvirt_domain.erb
+++ b/templates/libvirt_domain.erb
@@ -22,7 +22,7 @@
   <devices>
     <emulator><%= qemu_bin %></emulator>
     <disk type='file' device='disk'>
-      <driver name='qemu' type='raw'/>
+      <driver name='qemu' type='<%= image_type %>'/>
       <source file='<%= disk %>'/>
       <target dev='vda' bus='virtio'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>


### PR DESCRIPTION
Now we can select image type by provider configuration

```
kvm.image_type
```

from `raw` or `qcow2`. Default: `raw`

fix and proposal for #24
