### PR TITLE
Fix a typo in the KVM version exception

### DIFF
--- a/lib/vagrant-kvm/driver/driver.rb
+++ b/lib/vagrant-kvm/driver/driver.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
           @version = read_version
           if @version < "1.2.0"
             raise Errors::KvmInvalidVersion,
-              :actual => @version, :required => "< 1.2.0"
+              :actual => @version, :required => ">= 1.2.0"
           end
 
           # Get storage pool if it exists


### PR DESCRIPTION
This commit fixes a minor typo in the exception raised when
the KVM version is not sufficient for this plugin. This will
make errors messages on Debian Wheezy and Ubuntu 12.04 more
helpful.
