### PR TITLE
Allow resuming saved machine state when gui is enabled

### DIFF
--- a/lib/vagrant-kvm/action/boot.rb
+++ b/lib/vagrant-kvm/action/boot.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
         def call(env)
           @env = env
 
-          if @env[:machine].provider_config.gui
+          if @env[:machine].provider_config.gui and @env[:machine_action] != :resume
             env[:machine].provider.driver.set_gui
           end
 


### PR DESCRIPTION
Attempting to resume a suspended (saved) machine would result in:

```
Call to virDomainUndefine failed: Requested operation is not valid: 
Refusing to undefine while domain managed save image exists
(Libvirt::Error)
```

To mitigate this, do not attempt to modify the saved VM when resuming.
