### PR TITLE
make the path of qemu binary specifiable

### DIFF
--- a/lib/vagrant-kvm/action/import.rb
+++ b/lib/vagrant-kvm/action/import.rb
@@ -14,6 +14,8 @@ module VagrantPlugins
           image_type = env[:machine].provider_config.image_type
           image_type = 'raw' unless image_type == 'qcow2'
 
+          qemu_bin = env[:machine].provider_config.qemu_bin
+
           # Import the virtual machine (ovf or libvirt)
           # if a libvirt XML definition is present we use it
           # otherwise we convert the OVF
@@ -21,11 +23,11 @@ module VagrantPlugins
           box_file = env[:machine].box.directory.join("box.xml").to_s
           if File.file?(box_file)
             env[:machine].id = env[:machine].provider.driver.import(
-                        box_file, storage_path, image_type)
+                        box_file, storage_path, image_type, qemu_bin)
           else
             box_file = env[:machine].box.directory.join("box.ovf").to_s
             env[:machine].id = env[:machine].provider.driver.import_ovf(
-                        box_file, storage_path, image_type)
+                        box_file, storage_path, image_type, qemu_bin)
           end
 
           # If we got interrupted, then the import could have been

--- a/lib/vagrant-kvm/config.rb
+++ b/lib/vagrant-kvm/config.rb
@@ -26,10 +26,16 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :image_type
 
+      # path of qemu binary
+      #
+      # @return [String]
+      attr_accessor :qemu_bin
+
       def initialize
         @name             = UNSET_VALUE
         @gui              = UNSET_VALUE
         @image_type       = UNSET_VALUE
+        @qemu_bin         = UNSET_VALUE
       end
 
       # This is the hook that is called to finalize the object before it
@@ -41,6 +47,8 @@ module VagrantPlugins
         @gui = false if @gui == UNSET_VALUE
         # Default image type is a sparsed raw
         @image_type = 'raw' if @image_type == UNSET_VALUE
+        # Search qemu binary with the default behavior
+        @qemu_bin = nil if @qemu_bin == UNSET_VALUE
       end
     end
   end

--- a/lib/vagrant-kvm/driver/driver.rb
+++ b/lib/vagrant-kvm/driver/driver.rb
@@ -95,8 +95,9 @@ module VagrantPlugins
         # @param [String] xml Path to the libvirt XML file.
         # @param [String] path Destination path for the volume.
         # @param [String] image_type An image type for the volume.
+        # @param [String] qemu_bin A path of qemu binary.
         # @return [String] UUID of the imported VM.
-        def import(xml, path, image_type)
+        def import(xml, path, image_type, qemu_bin)
           @logger.info("Importing VM")
           # create vm definition from xml
           definition = File.open(xml) { |f|
@@ -115,6 +116,7 @@ module VagrantPlugins
           definition.disk = volume.path
           definition.name = @name
           definition.image_type = image_type
+          definition.qemu_bin = qemu_bin
           # create vm
           @logger.info("Creating new VM")
           domain = @conn.define_domain_xml(definition.as_libvirt)
@@ -127,8 +129,9 @@ module VagrantPlugins
         # @param [String] ovf Path to the OVF file.
         # @param [String] path Destination path for the volume.
         # @param [String] image_type An image type for the volume.
+        # @param [String] qemu_bin A path of qemu binary.
         # @return [String] UUID of the imported VM.
-        def import_ovf(ovf, path, image_type)
+        def import_ovf(ovf, path, image_type, qemu_bin)
           @logger.info("Importing OVF definition for VM")
           # create vm definition from ovf
           definition = File.open(ovf) { |f|
@@ -146,6 +149,7 @@ module VagrantPlugins
           definition.disk = volume.path
           definition.name = @name
           definition.image_type = image_type
+          definition.qemu_bin = qemu_bin
           # create vm
           @logger.info("Creating new VM")
           domain = @conn.define_domain_xml(definition.as_libvirt)

--- a/lib/vagrant-kvm/errors.rb
+++ b/lib/vagrant-kvm/errors.rb
@@ -12,6 +12,9 @@ module VagrantPlugins
       class KvmInvalidVersion < VagrantKVMError
         error_key(:kvm_invalid_version)
       end
+      class KvmNoQEMUBinary < VagrantKVMError
+        error_key(:kvm_no_qemu_binary)
+      end
     end
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -10,3 +10,5 @@ en:
       kvm_invalid_version: |-
         Invalid Kvm version detected: %{actual}, but a version %{required} is
         required.
+      kvm_no_qemu_binary: |-
+        Executable binary of qemu could not be found. Please re-examine %{cause}.


### PR DESCRIPTION
Current vagrant-kvm searches the qemu binary in a fixed manner
(as_libirt). This commit makes it specifiable via Vagrantfile like
this:

  config.vm.provider :kvm do |kvm|
    kvm.qemu_bin = "/custom/path/to/qemu-system-x86_64"
  end

Example error messages:
- User specified the binary, but it doesn't exist.
  $  sudo vagrant up --provider=kvm
  Bringing machine 'default' up with 'kvm' provider...
  [default] Importing base box 'base'...
  (100.00/100%)
  Executable binary of qemu could not be found. Please re-examine Vagrantfile (specified binary: asdf).
- Vagrant couldn't find the default installation of QEMU.
  $ sudo vagrant up --provider=kvm
  [default] Importing base box 'base'...
  (100.00/100%)
  Executable binary of qemu could not be found. Please re-examine QEMU installation.
