### PR TITLE
Fixed bug: PrepareGui action does not call builder app chain.

### DIFF
--- a/lib/vagrant-kvm/action/prepare_gui.rb
+++ b/lib/vagrant-kvm/action/prepare_gui.rb
@@ -10,6 +10,7 @@ module VagrantPlugins
           if env[:machine].provider_config.gui
             env[:machine].provider.driver.set_gui
           end
+          @app.call(env)
         end
       end
     end


### PR DESCRIPTION
PrepareGui action does not call `@app.call(env)`. This breaks the builder chain, and action_start will be ended in the middle of the startup.
