### PR TITLE
respect disabled  directive on synced_folder configuration

### DIFF
--- a/lib/vagrant-kvm/action/share_folders.rb
+++ b/lib/vagrant-kvm/action/share_folders.rb
@@ -28,11 +28,12 @@ module VagrantPlugins
               # Ignore NFS shared folders 
               #next if data[:nfs]
 
-              # convert to NFS share
-              data[:nfs] = true
-
-              # This to prevent overwriting the actual shared folders data
-              result[id] = data.dup
+              unless data[:disabled]
+                # convert to NFS share
+                data[:nfs] = true
+                # This to prevent overwriting the actual shared folders data
+                result[id] = data.dup
+              end
             end
           end
         end


### PR DESCRIPTION
Don't export when the case
config.vm.synced_folder ".", "/vagrant", :disabled => true

fixed #60

Signed-off-by: Hiroshi Miura miurahr@linux.com
