### PR TITLE
Better error handling when calling out to system commands

### DIFF
--- a/lib/vagrant-kvm/action/clear_forwarded_ports.rb
+++ b/lib/vagrant-kvm/action/clear_forwarded_ports.rb
@@ -5,6 +5,8 @@ module VagrantPlugins
   module ProviderKvm
     module Action
       class ClearForwardedPorts
+        include Util::Commands
+
         def initialize(app, env)
           @app = app
           @logger = Log4r::Logger.new("vagrant::kvm::action::clear_forwarded_ports")
@@ -18,7 +20,7 @@ module VagrantPlugins
             redir_pids.each do |pid|
               next unless is_redir_pid?(pid)
               @logger.debug "Killing pid #{pid}"
-              system "pkill -TERM -P #{pid}"
+              run_command "pkill -TERM -P #{pid}"
             end
 
             remove_redir_pids

--- a/lib/vagrant-kvm/action/forward_ports.rb
+++ b/lib/vagrant-kvm/action/forward_ports.rb
@@ -5,6 +5,8 @@ module VagrantPlugins
   module ProviderKvm
     module Action
       class ForwardPorts
+        include Util::Commands
+
         def initialize(app, env)
           @app    = app
           @logger = Log4r::Logger.new("vagrant::kvm::action::forward_ports")
@@ -94,7 +96,7 @@ module VagrantPlugins
         end
 
         def redir_installed?
-          system "which redir > /dev/null"
+          run_command "which redir > /dev/null"
         end
       end
     end

--- a/lib/vagrant-kvm/action/import.rb
+++ b/lib/vagrant-kvm/action/import.rb
@@ -2,8 +2,11 @@ module VagrantPlugins
   module ProviderKvm
     module Action
       class Import
+        include Util::Commands
+
         def initialize(app, env)
           @app = app
+          @logger = Log4r::Logger.new("vagrant::kvm::action::import")
         end
 
         def call(env)
@@ -99,17 +102,22 @@ module VagrantPlugins
         def volume_size(vol_path)
           # default values
           vol_vsize = {:size => 10, :unit => 'G'}
-          vsize_regex = %r{virtual size:\s+(?<size>\d+(\.\d+)?)(?<unit>.)\s+\((?<bytesize>\d+)\sbytes\)}
-          diskinfo = %x[qemu-img info #{vol_path}]
-          diskinfo.each_line do |line|
-            result = line.match(vsize_regex)
-            if result
-              # always take the size in bytes to avoid conversion
-              vol_vsize = {:size => result[:bytesize], :unit => "B"}
-              break
+          begin
+            vsize_regex = %r{virtual size:\s+(?<size>\d+(\.\d+)?)(?<unit>.)\s+\((?<bytesize>\d+)\sbytes\)}
+            diskinfo = %x[qemu-img info #{vol_path}]
+            diskinfo.each_line do |line|
+              result = line.match(vsize_regex)
+              if result
+                # always take the size in bytes to avoid conversion
+                vol_vsize = {:size => result[:bytesize], :unit => "B"}
+                break
+              end
             end
+          rescue Errors::KvmFailedCommand =>e
+            @logger.error 'Failed to find volume size. Using defaults.'
+            @logger.error e
           end
-          return vol_vsize
+          vol_vsize
         end
 
         def recover(env)

--- a/lib/vagrant-kvm/driver/driver.rb
+++ b/lib/vagrant-kvm/driver/driver.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
 
         include Util
         include Errors
+        include Util::Commands
 
         # enum for states return by libvirt
         VM_STATE = [
@@ -47,9 +48,9 @@ module VagrantPlugins
           unless @kvm
             case File.read('/proc/cpuinfo')
             when /vmx/
-              @kvm = true if system("sudo /sbin/modprobe kvm-intel")
+              @kvm = true if run_command("sudo /sbin/modprobe kvm-intel")
             when /svm/
-              @kvm = true if system("sudo /sbin/modprobe kvm-amd")
+              @kvm = true if run_command("sudo /sbin/modprobe kvm-amd")
             else
               # looks like virtualization is not supported
             end
@@ -152,7 +153,8 @@ module VagrantPlugins
         # @param [String] qemu_bin Path of qemu binary.
         # @return [String] UUID of the imported VM.
         def import(xml, box_type, volume_name, image_type, qemu_bin, cpus, memory_size, cpu_model)
-          @logger.info("Importing VM")
+          @logger.info("Importing VM #{@name}")
+
           # create vm definition from xml
           definition = File.open(xml) { |f|
             Util::VmDefinition.new(f.read, box_type) }
@@ -271,6 +273,7 @@ module VagrantPlugins
         end
 
         def set_mac_address(mac)
+          @logger.debug("Setting mac address to #{mac}")
           domain = @conn.lookup_domain_by_uuid(@uuid)
           definition = Util::VmDefinition.new(domain.xml_desc, 'libvirt')
           definition.set_mac(mac)
@@ -339,7 +342,7 @@ module VagrantPlugins
           to_path = File.dirname(xml_path)
           new_path = File.join(to_path, new_disk)
           @logger.info("create disk image #{new_path}")
-          system("qemu-img convert -S 16k -O qcow2 #{disk_image} #{new_path}")
+          run_command("qemu-img convert -S 16k -O qcow2 #{disk_image} #{new_path}")
           # write out box.xml
           definition.disk = new_disk
           definition.unset_gui

--- a/lib/vagrant-kvm/errors.rb
+++ b/lib/vagrant-kvm/errors.rb
@@ -6,23 +6,33 @@ module VagrantPlugins
       class VagrantKVMError < Vagrant::Errors::VagrantError
         error_namespace("vagrant_kvm.errors")
       end
+
       class KvmNoConnection < VagrantKVMError
         error_key(:kvm_no_connection)
       end
+
       class KvmInvalidVersion < VagrantKVMError
         error_key(:kvm_invalid_version)
       end
+
       class KvmNoQEMUBinary < VagrantKVMError
         error_key(:kvm_no_qemu_binary)
       end
+
       class KvmFailImageConversion < VagrantKVMError
         error_key(:kvm_fail_image_conversion)
       end
+
       class KvmImageUploadError < VagrantKVMError
         error_key(:kvm_fail_image_conversion)
       end
+
       class KvmBadBoxFormat < VagrantKVMError
         error_key(:kvm_fail_image_conversion)
+      end
+
+      class KvmFailedCommand < VagrantKVMError
+        error_key(:kvm_command_failed)
       end
     end
   end

--- a/lib/vagrant-kvm/util.rb
+++ b/lib/vagrant-kvm/util.rb
@@ -7,6 +7,7 @@ module VagrantPlugins
       autoload :VmDefinition, util_root.join("vm_definition")
       autoload :NetworkDefinition, util_root.join("network_definition")
       autoload :KvmTemplateRenderer, util_root.join("kvm_template_renderer")
+      autoload :Commands, util_root.join("commands")
     end
   end
 end

--- a/lib/vagrant-kvm/util/commands.rb
+++ b/lib/vagrant-kvm/util/commands.rb
@@ -1,0 +1,15 @@
+module VagrantPlugins
+  module ProviderKvm
+    module Util
+      module Commands
+        def run_command(cmd)
+          unless res = system(cmd)
+            raise Errors::KvmFailedCommand, "System command #{cmd} returned with error code #{res}"
+          end
+          res
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
I've add several issue with this plugin that were hard to debug because qemu-img would fail, but the plugin would carry on regardless. 

This change will raise an exception with the full command that caused the failure. 
