### PR TITLE
Prefer the binary qemu-system-* over qemu-kvm or kvm.

### DIFF
--- a/lib/vagrant-kvm/util/vm_definition.rb
+++ b/lib/vagrant-kvm/util/vm_definition.rb
@@ -82,9 +82,9 @@ module VagrantPlugins
           else
             # RedHat and Debian-based systems have different executable names
             # depending on version/architectures
-            qemu_bin_list = [ '/usr/bin/qemu-kvm', '/usr/bin/kvm' ]
-            qemu_bin_list << '/usr/bin/qemu-system-x86_64' if @arch.match(/64$/)
-            qemu_bin_list << '/usr/bin/qemu-system-i386'   if @arch.match(/^i.86$/)
+            qemu_bin_list = ['/usr/bin/qemu-system-x86_64'] if @arch.match(/64$/)
+            qemu_bin_list = ['/usr/bin/qemu-system-i386']   if @arch.match(/^i.86$/)
+            qemu_bin_list += [ '/usr/bin/qemu-kvm', '/usr/bin/kvm' ]
           end
 
           qemu_bin = qemu_bin_list.detect { |binary| File.exists? binary }


### PR DESCRIPTION
The kvm binary is deprecated, so we shouldn't use it if the newer binary exists.

INFO runner: Running action: #Vagrant::Action::Builder:0x007fdf108a97f0
/home/pittsb/.vagrant.d/gems/gems/vagrant-kvm-0.1.4/lib/vagrant-kvm/driver/driver.rb:333:in `create': Call to virDomainCreateWithFlags failed: internal error: process exited while connecting to monitor: W: kvm binary is deprecated, please use qemu-system-x86_64 instead (Libvirt::Error)
