### PR TITLE
add proper sata controler to box.xml

### DIFF
--- a/templates/libvirt_domain.erb
+++ b/templates/libvirt_domain.erb
@@ -27,10 +27,14 @@
       <target dev='vda' bus='<%= disk_bus %>'/>
     <% if disk_bus == 'virtio' %>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </disk>
     <% else %>
       <address type='drive' controller='0' bus='0' target='0' unit='0'/>
-    <% end %>
     </disk>
+    <controller type='<%= disk_bus %>' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </controller>
+    <% end %>
     <controller type='usb' index='0'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
     </controller>


### PR DESCRIPTION
When sata disk_bus is specified,  add sata controller in vm_definition.

Signed-off-by: Hiroshi Miura miurahr@linux.com
