### PR TITLE
Update ruby-libvirt dependency to 0.5.x

### DIFF
--- a/vagrant-kvm.gemspec
+++ b/vagrant-kvm.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.requirements << 'KVM/QEMU, v1.2.0 or greater'
 
-  s.add_runtime_dependency "ruby-libvirt", "~> 0.5.2"
+  s.add_runtime_dependency "ruby-libvirt", "~> 0.5", ">= 0.5.2"
 
   s.add_development_dependency "pry"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Ruby-libvirt 0.5.0 released and  include network definition update,
which is necessary to support multi-VM/multi network support.

https://rubygems.org/gems/ruby-libvirt
