### PR TITLE
Set the vm name again after boot

### DIFF
--- a/lib/vagrant-kvm/action.rb
+++ b/lib/vagrant-kvm/action.rb
@@ -234,6 +234,7 @@ module VagrantPlugins
             # If the VM is NOT created yet, then do the setup steps
             if !env[:result]
               b2.use CheckBox
+              b2.use SetName
               b2.use Import
               b2.use MatchMACAddress
             end


### PR DESCRIPTION
Currently, the first time a `vagrant up` is issued, it fails because the vm name is missing. The reason is that CheckBox action reloads the environment, and thus, looses the name of the vm. 
