### PR TITLE
Force the version of log4r

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ group :development do
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
   gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git"
+  gem "log4r", '1.1.10'
 end


### PR DESCRIPTION
Looks like log4r was updated yesterday with a breaking change to its API and vagrant's gemspec allows it.

This should force vagrant-kvm test to use an older version. 
