### PR TITLE
Vagrant don't run ruby <2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ before_install:
   - sudo apt-get install -qq libvirt-dev libvirt-bin qemu-kvm qemu
   - sudo usermod -G kvm,libvirtd $USER
 rvm:
-  - 1.9.3
   - 2.0.0
 script: "bundle exec rspec spec/vagrant-kvm/"


### PR DESCRIPTION
https://github.com/mitchellh/vagrant/issues/2895#issuecomment-33332861

```
mitchellh commented an hour ago

Vagrant doesn't work with Ruby < 2
```

Signed-off-by: Hiroshi Miura miurahr@linux.com
