### PR TITLE
fix primary ide pci id: 0000:0:1.1

### DIFF
--- a/templates/libvirt_domain.erb
+++ b/templates/libvirt_domain.erb
@@ -27,16 +27,21 @@
       <target dev='vda' bus='<%= disk_bus %>'/>
   <% if disk_bus == 'virtio' %>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
-    </disk>
   <% else %>
       <address type='drive' controller='0' bus='0' target='0' unit='0'/>
-    </disk>
-    <controller type='<%= disk_bus %>' index='0'>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
-    </controller>
   <% end %>
+    </disk>
+    <controller type='ide' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
+    </controller>
     <controller type='usb' index='0'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
+    </controller>
+    <controller type='sata' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>
+    </controller>
+    <controller type='scsi' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
     </controller>
     <controller type='virtio-serial' index='0'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>


### PR DESCRIPTION
- ide, sata and scsi has each pci id.
- ide is on 0000:0:1.1

it fixes following error with box that have IDE drive. 

```
/home/vagrant/.vagrant.d/gems/gems/vagrant-kvm-0.1.4/lib/vagrant-kvm/driver/driver.rb:165:in `define_domain_xml': Call to virDomainDefineXML failed: internal error Primary IDE controller must have PCI address 0:0:1.1 (Libvirt::DefinitionError)
    from /home/vagrant/.vagrant.d/gems/gems/vagrant-kvm-0.1.4/lib/vagrant-kvm/driver/driver.rb:165:in `import'
```

Signed-off-by: Hiroshi Miura miurahr@linux.com
