### PR TITLE
template: appears sata/scsi only when nesseary

### DIFF
--- a/templates/libvirt_domain.erb
+++ b/templates/libvirt_domain.erb
@@ -37,12 +37,16 @@
     <controller type='usb' index='0'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
     </controller>
+  <% if disk_bus == 'sata' %>
     <controller type='sata' index='0'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>
     </controller>
+  <% end %>
+  <% if disk_bus == 'scsi' %>
     <controller type='scsi' index='0'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
     </controller>
+  <% end %>
     <controller type='virtio-serial' index='0'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
     </controller>


### PR DESCRIPTION
- sata disk controller does not support suspend.
  It is appears only when it is neccesary.
- fix #156

Signed-off-by: Hiroshi Miura miurahr@linux.com
