### PR TITLE
9p: use md5 of guest path as mount_tag

### DIFF
--- a/lib/vagrant-kvm/cap/mount_p9.rb
+++ b/lib/vagrant-kvm/cap/mount_p9.rb
@@ -17,8 +17,8 @@ module VagrantPlugins
             machine.communicate.sudo("mkdir -p #{expanded_guest_path}")
 
             # Mount
-            # tag maximum len is 11
-            mount_tag = Digest::MD5.new.update(name).to_s[0,11]
+            # tag maximum len is 31
+            mount_tag = Digest::MD5.new.update(name).to_s[0,31]
 
             mount_opts="-o trans=virtio"
             mount_opts += ",access=#{options[:owner]}" if options[:owner]

--- a/lib/vagrant-kvm/synced_folder.rb
+++ b/lib/vagrant-kvm/synced_folder.rb
@@ -14,8 +14,8 @@ module VagrantPlugins
           # access_mode can be squash, mapped, or passthrough
           accessmode = data.has_key?(:access_mode)? data[:access_mode] : 'squash'
           accessmode = 'squash' unless accessmode == 'mapped' || accessmode == 'passthrough'
-          # tag maximum len is 11
-          tag = Digest::MD5.new.update(id).to_s[0,11]
+          # tag maximum len is 31
+          tag = Digest::MD5.new.update(id).to_s[0,31]
           defs << {
             :mount_tag => tag,
             :hostpath => data[:hostpath].to_s,


### PR DESCRIPTION
-mount_tag is limited 11 chars.
- fixed #203

Signed-off-by: Hiroshi Miura miurahr@linux.com
