### PR TITLE
v0.2.0dev: Add multifunction=on option to pci network device

### DIFF
--- a/templates/libvirt_domain.erb
+++ b/templates/libvirt_domain.erb
@@ -62,7 +62,7 @@
       <source network='<%= network %>'/>
       <model type='<%= network_model %>'/>
       <%- # WARN: slot 0x03 is hardcoded in vm_definition.rb:inject_nics() -%>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0' />
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0' multifunction='on' />
     </interface>
     <serial type='pty'>
       <target port='0'/>


### PR DESCRIPTION
I've got the following error during `vagrant up`:

```
$ VAGRANT_LOG=debug vagrant up --provider=kvm
... snip...
ERROR warden: Error occurred: Call to virDomainDefineXML failed: XML error: Attempted double use of PCI Address 0000:00:03.1 (may need "multifunction='on'" for device on function 0)
 INFO warden: Beginning recovery process...
 INFO warden: Calling recover: #<VagrantPlugins::ProviderKvm::Action::Import:0x000000012552f0>
ERROR warden: Error occurred: Call to virDomainLookupByUUID failed: Domain not found: no domain with matching uuid 'a4e3fe7e-c083-4a86-b70b-4704b9d24404'
... snip...
/home/taka/.vagrant.d/gems/gems/vagrant-kvm-0.2.0.dev/lib/vagrant-kvm/driver/driver.rb:417:in `lookup_domain_by_uuid': Call to virDomainLookupByUUID failed: Domain not found: no domain with matching uuid 'a4e3fe7e-c083-4a86-b70b-4704b9d24404' (Libvirt::RetrieveError)
```

My environment is as following:
- qemu-system-x86 2.0.0+dfsg-4
- vagrant-kvm 0.2.0.dev (1297c0afe15d8a47d6b1b68e037c12e62741316e)
- Vagrant 1.6.2
- libvirt 1.2.4-1
