### PR TITLE
git ignores rbenv/rvm files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@
 pkg/*
 tags
 Gemfile.lock
+vendor/ruby
+
+# Rbenv/RVM
+.ruby-version
+.rvmrc
 
 # Vagrant
 .vagrant


### PR DESCRIPTION
ignores rbenv and rvm files on git repository.

Signed-off-by: Hiroshi Miura miurahr@linux.com
