### PR TITLE
Only allow qemu group access to home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ To avoid this, please check and change your home directory and
 child directories permission to permit qemu user access to `~/.vagrant.d/tmp/storage-pool/`
 
 ```bash
-$ chmod go+x /home/<your account>
+$ setfacl -m g:qemu:x /home/<your account>
 ```
 
 Another option is to run qemu/kvm as the root user by changing the


### PR DESCRIPTION
There is no need to open up permission for all users into the home directory, you can go with using ACL for only allowing the qemu group execute permissions.
