### PR TITLE
Issue #270: Add control for cpu_model and cpu_feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,16 @@ then you can simply run `vagrant up` to use the kvm provider.
 
 There are some provider specific parameter to control VM definition.
 
-* `cpu_model` - cpu architecture: 'i686' or 'x86\_64': default is x86\_64. Note
-  that your base box should specify this.
+* `cpu_model` - CPU model to use for the guest. This parameter can be used to
+                enable nested virtualization when paired with the `cpu_feature`
+                parameter. Typical value might be "core2duo".
+* `cpu_feature` - Specify CPU features that you want in the guest. This can be
+                used to enable nested virtualization when paired with the
+                `cpu_model` parameter. This parameter takes two options; the
+                `policy` and the `name` of the feature. You can specify the
+                `cpu_feature` parameter many times to enable multiple features.
+                This parameter is only used if the `cpu_model` parameter is
+                defined.
 * `core_number` - number of cpu cores.
 * `memory_size` - memory size such as 512m, 1GiB, 100000KiB, unit is KiB if
   unspecified.
@@ -214,6 +222,15 @@ image. This is slower but allows multiple VMs to be booted at the same time.
 * `virtio_rng` - boolean for optional virtio device of random number generator.
   QEMU 1.3.0 and after support this device. default `false`
 
+### Example KVM provider section of the Vagrantfile
+
+```ruby
+config.vm.provider "kvm" do |k|
+  k.cpu_model = "core2duo"
+  k.cpu_feature :require, "vmx"
+  k.cpu_feature :require, "ht"
+end
+```
 
 ## Comparison with [Vagrant-libvirt](https://github.com/pradels/vagrant-libvirt)
 

--- a/lib/vagrant-kvm/action/import.rb
+++ b/lib/vagrant-kvm/action/import.rb
@@ -33,6 +33,7 @@ module VagrantPlugins
             :qemu_bin      => provider_config.qemu_bin,
             :cpus          => provider_config.core_number,
             :cpu_model     => provider_config.cpu_model,
+            :cpu_features  => provider_config.cpu_features,
             :machine_type  => provider_config.machine_type,
             :network_model => provider_config.network_model,
             :video_model   => provider_config.video_model,

--- a/lib/vagrant-kvm/config.rb
+++ b/lib/vagrant-kvm/config.rb
@@ -48,10 +48,15 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :qemu_bin
 
-      # cpu model
+      # CPU model requested by the guest
       #
-      # @return [String]: x86_64/i386
+      # @return [String]
       attr_accessor :cpu_model
+
+      # An array of CPU features provided by the CPU model
+      #
+      # @return [Array]
+      attr_reader :cpu_features
 
       # memory size in bytes
       # default: defined in box
@@ -95,6 +100,7 @@ module VagrantPlugins
         @image_mode       = UNSET_VALUE
         @qemu_bin         = UNSET_VALUE
         @cpu_model        = UNSET_VALUE
+        @cpu_features     = []
         @memory_size      = UNSET_VALUE
         @core_number      = UNSET_VALUE
         @vnc_port         = UNSET_VALUE
@@ -126,6 +132,16 @@ module VagrantPlugins
         @customizations << [event, command]
       end
 
+      # Define CPU features desired when defining the cpu_model
+      #
+      # Call multiple times to add different features
+      # @param policy The meaning of the feature depends on the policy
+      #               :force, :require, :optional, :disable, :forbid
+      # @param name The name of the CPU feature.
+      def cpu_feature(policy, name)
+        @cpu_features << [policy, name]
+      end
+
       # This is the hook that is called to finalize the object before it
       # is put into use.
       def finalize!
@@ -150,9 +166,9 @@ module VagrantPlugins
         end
         # Search qemu binary with the default behavior
         @qemu_bin = nil if @qemu_bin == UNSET_VALUE
-        # Default cpu model is x86_64, acceptable only x86_64/i686
-        @cpu_model = 'x86_64' if @cpu_model == UNSET_VALUE
-        @cpu_model = 'x86_64' unless @cpu_model =~ /^(i686|x86_64)$/
+        # CPU model is unset by default.
+        @cpu_model = nil if @cpu_model == UNSET_VALUE
+        @cpu_features = [] if @cpu_features == UNSET_VALUE
         # Process memory size directive
         # accept the case
         # integer recgnized as KiB

--- a/lib/vagrant-kvm/util/vm_definition.rb
+++ b/lib/vagrant-kvm/util/vm_definition.rb
@@ -87,6 +87,15 @@ module VagrantPlugins
           if doc.elements["/domain/uuid"]
             update({:uuid => doc.elements["/domain/uuid"].text})
           end
+          if doc.elements["/domain/cpu/model"]
+            cpu_features = []
+            doc.elements.each("/domain/cpu/feature") do |cpu_feature|
+              cpu_features << [cpu_feature.attributes["policy"],
+                               cpu_feature.attributes["name"]]
+            end
+            update({:cpu_model => doc.elements["/domain/cpu/model"].text,
+                    :cpu_features => cpu_features})
+          end
           # VNC
           if doc.elements["//devices/graphics"]
             attrs = doc.elements["//devices/graphics"].attributes

--- a/spec/vagrant-kvm/config_spec.rb
+++ b/spec/vagrant-kvm/config_spec.rb
@@ -16,8 +16,8 @@ describe  VagrantPlugins::ProviderKvm::Config do
   end
 
   describe "#cpu_model" do
-    it "default to x86-64" do
-      should_default(:cpu_model, 'x86_64')
+    it "defaults to nil" do
+      should_default(:cpu_model, nil)
     end
   end
 

--- a/templates/libvirt_domain.erb
+++ b/templates/libvirt_domain.erb
@@ -17,6 +17,14 @@
     <type arch='<%= arch %>' machine='<%= machine_type %>'>hvm</type>
     <boot dev='hd'/>
   </os>
+  <% if cpu_model %>
+  <cpu match='exact'>
+    <model><%= cpu_model %></model>
+    <% cpu_features.each do |policy, name| %>
+    <feature policy='<%= policy %>' name='<%= name %>'/>
+    <% end %>
+  </cpu>
+  <% end %>
   <features>
     <acpi/>
     <apic/>


### PR DESCRIPTION
Add configuration parameters for `cpu_model` and `cpu_feature`
which control the setting of the following xml block.

```
<cpu mode='custom' match='exact'>
    <model fallback='allow'>core2duo</model>
    <feature policy='require' name='vmx'/>
</cpu>
```

This allows a vagrant KVM guest to provide nested virtualization.

NOTE: The `cpu_model` parameter was previously was listed to define
the cpu architecture but it actually was not doing anything. This
parameter has been reused to reflect the preferred guest cpu model.
